### PR TITLE
Add json flag to req->node

### DIFF
--- a/src/kvlt/platform/http.cljs
+++ b/src/kvlt/platform/http.cljs
@@ -26,7 +26,7 @@
        (when query-string
          (str "?" query-string))))
 
-(defn req->node [{:keys [body kvlt.platform/timeout kvlt.platform/insecure?] :as req}]
+(defn req->node [{:keys [body json kvlt.platform/timeout kvlt.platform/insecure?] :as req}]
   (cond->
       {:uri      (compose-url req)
        :method   (-> req :request-method name str/upper-case)
@@ -34,6 +34,7 @@
        :encoding nil
        :gzip     true}
     body      (assoc :body body)
+    json      (assoc :json json)
     timeout   (assoc :timeout timeout)
     insecure? (assoc :rejectUnauthorized false)))
 


### PR DESCRIPTION
To provide a json as the body of a POST request on Node JS, Request library need to be passed the flag json to true.

Also given the number of different parameter that can be passed to the Reaquest library, don't you think it might be usefull to use req as a reference point ?