### PR TITLE
delay loading of EventSource and WebSocket

### DIFF
--- a/src/kvlt/platform/event_source.cljs
+++ b/src/kvlt/platform/event_source.cljs
@@ -12,7 +12,8 @@
   (if (exists? js/EventSource)
     (js/EventSource. url)
     (try
-      (@eventsource-node. url)
+      (let [es @eventsource-node]
+        (es. url))
       (catch js/Error e
         (log/error "EventSource is not available")
         (throw e)))))

--- a/src/kvlt/platform/websocket.cljs
+++ b/src/kvlt/platform/websocket.cljs
@@ -14,7 +14,8 @@
   (if (exists? js/WebSocket)
     (js/WebSocket. url)
     (try
-      (@websocket-node. url)
+      (let [ws @websocket-node]
+        (ws. url))
       (catch js/Error e
         (log/error "WebSocket is not available")
         (throw e)))))


### PR DESCRIPTION
Delay the loading of EventSource and WebSocket until they are used. This allows kvlt to be used on browsers that don't support them as long as the features are not actually used.