### PR TITLE
support options for Server Sent Events

### DIFF
--- a/src/kvlt/core.cljc
+++ b/src/kvlt/core.cljc
@@ -89,14 +89,21 @@
   re-established.
 
   `as` is some symbolic value (defaulting to `:string` - no-op) which
-  is used as [[kvlt.event-source/format-event]]'s dispatch value.  ```
+  is used as [[kvlt.event-source/format-event]]'s dispatch value.
+
+  `options` is a map containing key/value options to pass to the
+  underlying implementation.  The accepted options vary by platform, but
+  a typical use is to pass additional headers to the request.  For example,
+  {:headers {\"Cookie\" \"test=test\"}} to add a cookie to the request.
   "
-  [url & [{:keys [events as chan close?]
+  [url & [{:keys [events as chan close? options]
            :or {events #{:message}
                 as     :string
-                close? true}}]]
+                close? true
+                options {}}}]]
   (platform.event-source/request!
    url {:events events
         :format as
         :chan   chan
-        :close? close?}))
+        :close? close?
+        :options options}))

--- a/src/kvlt/core.cljc
+++ b/src/kvlt/core.cljc
@@ -92,9 +92,15 @@
   is used as [[kvlt.event-source/format-event]]'s dispatch value.
 
   `options` is a map containing key/value options to pass to the
-  underlying implementation.  The accepted options vary by platform, but
-  a typical use is to pass additional headers to the request.  For example,
-  {:headers {\"Cookie\" \"test=test\"}} to add a cookie to the request.
+  underlying implementation. A typical case is to pass additional
+  headers to the request.  For example, set options to:
+
+      {:headers {\"Cookie\" \"test=test\"}}
+
+  to add a cookie to the request. Note that the accepted options vary
+  by platform. Clojure only supports :headers. Consult the API specs
+  for [browsers](https://developer.mozilla.org/en-US/docs/Web/API/EventSource/EventSource)
+  and for [node](https://www.npmjs.com/package/eventsource).
   "
   [url & [{:keys [events as chan close? options]
            :or {events #{:message}

--- a/src/kvlt/core.cljc
+++ b/src/kvlt/core.cljc
@@ -92,15 +92,16 @@
   is used as [[kvlt.event-source/format-event]]'s dispatch value.
 
   `options` is a map containing key/value options to pass to the
-  underlying implementation. A typical case is to pass additional
-  headers to the request.  For example, set options to:
+  underlying implementation. A cookie can be added to the request,
+  for example, by setting `options` to:
 
       {:headers {\"Cookie\" \"test=test\"}}
 
-  to add a cookie to the request. Note that the accepted options vary
-  by platform. Clojure only supports :headers. Consult the API specs
-  for [browsers](https://developer.mozilla.org/en-US/docs/Web/API/EventSource/EventSource)
-  and for [node](https://www.npmjs.com/package/eventsource).
+  for Clojure and Node environments. The accepted options vary by
+  platform, with unknown options being silently ignored. Clojure
+  only supports `:headers`. Consult [browser](https://developer.mozilla.org/en-US/docs/Web/API/EventSource/EventSource)
+  and [node](https://www.npmjs.com/package/eventsource) API
+  specifications for details.
   "
   [url & [{:keys [events as chan close? options]
            :or {events #{:message}

--- a/test/kvlt/test/platform/event_source.cljc
+++ b/test/kvlt/test/platform/event_source.cljc
@@ -11,11 +11,20 @@
 (def local-url (str "http://localhost:" 5000 "/events"))
 
 (deftest ^{:kvlt/skip #{:phantom}} message-events
-  (util/with-result
-    (util/channel-promise (event-source/request! local-url))
-    (fn [{:keys [data id] :as m}]
-      (is= "A bunch of\n events " data)
-      (is (nil? id)))))
+         (util/with-result
+           (util/channel-promise (event-source/request! local-url))
+           (fn [{:keys [data id] :as m}]
+             (is= "A bunch of\n events " data)
+             (is (nil? id)))))
+
+(deftest ^{:kvlt/skip #{:phantom}} header-events
+         (util/with-result
+           (util/channel-promise (event-source/request! local-url
+                                                        {:events #{:header}
+                                                         :options {:headers {"x-kvlt-test" "ok"}}}))
+           (fn [{:keys [data id] :as m}]
+             (is= "ok" data)
+             (is (nil? id)))))
 
 (deftest ^{:kvlt/skip #{:phantom}} odd-events
   (util/with-result

--- a/test/kvlt/test/platform/event_source.cljc
+++ b/test/kvlt/test/platform/event_source.cljc
@@ -11,20 +11,20 @@
 (def local-url (str "http://localhost:" 5000 "/events"))
 
 (deftest ^{:kvlt/skip #{:phantom}} message-events
-         (util/with-result
-           (util/channel-promise (event-source/request! local-url))
-           (fn [{:keys [data id] :as m}]
-             (is= "A bunch of\n events " data)
-             (is (nil? id)))))
+  (util/with-result
+    (util/channel-promise (event-source/request! local-url))
+    (fn [{:keys [data id] :as m}]
+      (is= "A bunch of\n events " data)
+      (is (nil? id)))))
 
 (deftest ^{:kvlt/skip #{:phantom :browser}} header-events
-         (util/with-result
-           (util/channel-promise (event-source/request! local-url
-                                                        {:events #{:header}
-                                                         :options {:headers {"x-kvlt-test" "ok"}}}))
-           (fn [{:keys [data id] :as m}]
-             (is= "ok" data)
-             (is (nil? id)))))
+  (util/with-result
+    (util/channel-promise (event-source/request! local-url
+                                                 {:events #{:header}
+                                                  :options {:headers {"x-kvlt-test" "ok"}}}))
+    (fn [{:keys [data id] :as m}]
+      (is= "ok" data)
+      (is (nil? id)))))
 
 (deftest ^{:kvlt/skip #{:phantom}} odd-events
   (util/with-result

--- a/test/kvlt/test/platform/event_source.cljc
+++ b/test/kvlt/test/platform/event_source.cljc
@@ -17,7 +17,7 @@
              (is= "A bunch of\n events " data)
              (is (nil? id)))))
 
-(deftest ^{:kvlt/skip #{:phantom}} header-events
+(deftest ^{:kvlt/skip #{:phantom :browser}} header-events
          (util/with-result
            (util/channel-promise (event-source/request! local-url
                                                         {:events #{:header}

--- a/test/kvlt/test/server.clj
+++ b/test/kvlt/test/server.clj
@@ -48,6 +48,9 @@
         send!  #(stream/put! stream (apply str %&))]
     (send! "data: A bunch of\r\ndata: ")
     (send! " events \n\nHorseshit\n\n")
+    (when-let [x-kvlt-test (get-in req [:headers "x-kvlt-test"])]
+      (send! "event: header\n")
+      (send! "data: " x-kvlt-test "\r\n\r\n"))
     (d/loop [i 0]
       (if (< i 100)
         (do


### PR DESCRIPTION
Allow (platform-dependent) options to be passed to the underlying EventSource implementation for Server Sent Events.