### PR TITLE
Support `kvlt.transport/max-frame-payload` transport option to `websocket!` on the JVM.

### DIFF
--- a/src/kvlt/core.cljc
+++ b/src/kvlt/core.cljc
@@ -63,6 +63,9 @@
   websocket itself.  The `read-chan` and `write-chan` options can be
   specified to e.g. apply a transducer to incoming/outgoing values.
 
+  Platform specific options, such as `max-frame-payload` for Clojure, can be
+  specified as keywords in the `kvlt.platform` namespace.
+
   Closing the returned channel terminates the websocket connection,
   and will close the underlying read & write channels (unless `close?`
   is false, in which event it'll close neither).  The channel will be

--- a/test/kvlt/test/platform/websocket.cljc
+++ b/test/kvlt/test/platform/websocket.cljc
@@ -73,3 +73,18 @@
           (let [{:keys [kvlt.platform/stream]} (meta ch)]
             (async/close! ch)
             (is (manifold.stream/closed? stream)))))))
+
+#? (:clj
+    (deftest websocket-max-frame-payload
+      (util/with-result
+        (websocket/request!
+          (str "ws://localhost:" util/local-port "/ws-echo")
+          {:kvlt.platform/max-frame-payload 1})
+        (fn [ch]
+          (let [{:keys [kvlt.platform/stream]} (meta ch)]
+            (util/channel-promise
+              (go
+                (>! ch "longer than one")
+                (<! ch)
+                (is (manifold.stream/closed? stream))
+                (async/close! ch))))))))


### PR DESCRIPTION
This maps to the aleph option named `max-frame-payload`.

The test is a bit strange because this error is handled by the netty channel
exception handler in aleph and only logged, I don't think there's any way to
catch this error outside of aleph internals.

Fixes #31.