### PR TITLE
Generate doc-examples string at compile time

### DIFF
--- a/src/kvlt/util.cljc
+++ b/src/kvlt/util.cljc
@@ -56,16 +56,17 @@
 (defn pprint-str [x]
   (str/trimr (with-out-str (pprint/pprint x))))
 
+(defn examples->str [examples]
+  (str "\n\n```clojure\n"
+       (str/join
+         "\n\n"
+         (for [[before after] examples]
+           (cond-> (pprint-str before)
+                   after (str "\n  =>\n" (pprint-str after)))))
+       "\n```"))
+
 (defn doc-examples! [vvar examples]
-  (alter-meta!
-   vvar update :doc str
-   "\n\n```clojure\n"
-   (str/join
-    "\n\n"
-    (for [[before after] examples]
-      (cond-> (pprint-str before)
-        after (str "\n  =>\n" (pprint-str after)))))
-   "\n```"))
+  (alter-meta! vvar update :doc str (examples->str examples)))
 
 #? (:clj
     (defmacro fn-when [[binding] & body]
@@ -75,4 +76,4 @@
 
 #? (:clj
     (defmacro with-doc-examples! [vvar & examples]
-      `(doc-examples! #'~vvar (quote ~examples))))
+      `(alter-meta! #'~vvar update :doc str ~(examples->str examples))))


### PR DESCRIPTION
The pprint of the example doc strings at runtime incurs around a 50ms penalty on initialization. Flamegraph from Chrome: 
![image](https://user-images.githubusercontent.com/7741805/35125436-998a7b62-fc77-11e7-93f8-608fcee988c1.png)

You could technically do one better and generate the entire doc string without the alter-meta!, but I didn't want to muck with the defmw macro.
